### PR TITLE
Add option noCatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ function ctor(options, fn, initial) {
   }
 
   var Reduce = through2.ctor(options, function (chunk, encoding, callback) {
+    var err
+
     if (this.options.wantStrings) chunk = chunk.toString()
 
     // First chunk with no initial value set
@@ -19,10 +21,15 @@ function ctor(options, fn, initial) {
       return callback()
     }
 
-    try {
-      this._reduction = fn.call(this, this._reduction, chunk, this._index++)
-    } catch (e) {
-      var err = e
+    var args = [this._reduction, chunk, this._index++]
+    if (this.options.noCatch) {
+      this._reduction = fn.apply(this, args)
+    } else {
+      try {
+        this._reduction = fn.apply(this, args)
+      } catch (e) {
+        err = e
+      }
     }
     return callback(err)
   }, function (callback) {

--- a/test/index.js
+++ b/test/index.js
@@ -169,3 +169,28 @@ test("throw", function (t) {
     .pipe(summer)
     .pipe(concat({objectMode: true},combine))
 })
+
+test("noCatch", function (t) {
+  // Can't think of a way to test this. An error thrown from a stream seems uncatchable. To run this
+  // test please uncomment the two following comments, in the definitions of Sum and combine. If you
+  // see an uncaught exception in the output, everything works as it should.
+  t.end()
+
+  var Sum = reduce.ctor(function (prev, curr) {
+    // if (!isnumber(curr)) throw new Error("Values must be numeric")
+    return prev + parseFloat(curr)
+  })
+
+  function combine(result) {
+    // t.fail("Should not complete pipeline when error")
+  }
+
+  var summer = new Sum({objectMode: true, noCatch: true})
+  summer.on("error", function (err) {
+    t.fail("Should not emit an error event")
+  })
+
+  spigot({objectMode: true}, [2, 4, 8, 2, "cat", 8, 10])
+    .pipe(summer)
+    .pipe(concat({objectMode: true},combine))
+})


### PR DESCRIPTION
An extension to #3 . Should be useful:
- for stream-fundamentalists who don't throw :)
- and for those who want to omit the overhead of JS's exception handling.
