### PR TITLE
Add xtend to dependencies in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "isnumber": "~1.0.0",
     "stream-spigot": "~3.0.5",
     "tape": "~4.0.0",
-    "terminus": "~1.0.12",
-    "xtend": "~4.0.1"
+    "terminus": "~1.0.12"
   },
   "dependencies": {
-    "through2": "~2.0.0"
+    "through2": "~2.0.0",
+    "xtend": "~4.0.1"
   },
   "homepage": "https://github.com/brycebaril/through2-reduce"
 }


### PR DESCRIPTION
If `npm install --production` is used to build the through2-reduce package, xtend isn't installed as a dependency. xtend is required by the library unconditionally, and attemping to `require("./through2-reduce");` fails with an error with the current `package.json` if the dependencies are installed with the `--production` flag:

```
$ npm --version
2.14.4
$ npm install --production
through2@2.0.0 node_modules/through2
├── xtend@4.0.1
└── readable-stream@2.0.5 (string_decoder@0.10.31, isarray@0.0.1, process-nextick-args@1.0.6, inherits@2.0.1, util-deprecate@1.0.2, core-util-is@1.0.2)
$ cd ..
$ node
> through2_reduce = require("./through2-reduce");
Error: Cannot find module 'xtend'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/kacarstensen/through2-reduce/index.js:7:13)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
> 
```

Moving xtend into the main dependencies object resolves this issue:

```
$ git diff package.json
diff --git a/package.json b/package.json
index 9381d74..5910734 100644
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "isnumber": "~1.0.0",
     "stream-spigot": "~3.0.5",
     "tape": "~4.0.0",
-    "terminus": "~1.0.12",
-    "xtend": "~4.0.1"
+    "terminus": "~1.0.12"
   },
   "dependencies": {
-    "through2": "~2.0.0"
+    "through2": "~2.0.0",
+    "xtend": "~4.0.1"
   },
   "homepage": "https://github.com/brycebaril/through2-reduce"
 }
$ npm install --production
xtend@4.0.1 node_modules/xtend

through2@2.0.0 node_modules/through2
└── readable-stream@2.0.5 (string_decoder@0.10.31, isarray@0.0.1, inherits@2.0.1, util-deprecate@1.0.2, process-nextick-args@1.0.6, core-util-is@1.0.2)
$ cd ..
$ node
> reduce = require("./through2-reduce");
{ [Function: make]
  ctor: [Function: ctor],
  objCtor: [Function: objCtor],
  obj: [Function: obj] }
```
